### PR TITLE
update trivial to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@folio/stripes": "^1.0.0",
-    "@folio/trivial": "^1.2.0",
+    "@folio/trivial": "^1.3.0",
     "@folio/users": "^2.17.0",
     "react": "^16.3.0"
   },


### PR DESCRIPTION
Trivial was never released when we moved React from a hard to a peer
dependency, resulting in a conflict when trivial provides its own React
version in conflict with the one provided here. Trivial 1.3.0 moves
React to a peer.