### PR TITLE
restore semver-ish version in package.json::version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-sample-platform",
-  "version": "2023-R1 (Orchid)",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "stripes build stripes.config.js",


### PR DESCRIPTION
The package's `version` string must be a semver. Using a semantically meaningful string, since platforms don't follow semver, seemed like a good idea at the time but causes `yarn` to throw a wobbly when trying to install dependencies into a workspace:
```
Couldn't find package "@folio/stripes-sample-platform@2023-R1 (Orchid)"
required by "workspace-aggregator-838e0a76-a4d9-4d97-bd4c-fa65670fd08a@1.0.0"
on the "npm" registry.
```